### PR TITLE
Adicionar Plugin do Docusaurus para gerar API de Magias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ yarn-error.log*
 
 # Temp Image Upload Folder (used with VSCode)
 /temp
+
+/static/spells.json

--- a/data/spells-cjs.js
+++ b/data/spells-cjs.js
@@ -1,0 +1,27 @@
+const { resolve } = require('path');
+const { readdir } = require('fs').promises;
+
+async function getFiles(dir) {
+  const dirents = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(dirents.map((dirent) => {
+    const res = resolve(dir, dirent.name);
+    return dirent.isDirectory() ? getFiles(res) : res;
+  }));
+  return Array.prototype.concat(...files);
+}
+
+function getSpells() {
+  return new Promise((resolve, reject) => {
+    getFiles("data/").then((files) => {
+      let spells = files
+        .filter((path) => !path.includes('spells.js'))
+        .map((file) => require(file))
+
+      resolve(spells)
+    }).catch(err => {
+      reject(err)
+    })
+  })
+}
+
+module.exports = { getSpells }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,6 +91,7 @@ module.exports = {
     ],
   ],
   plugins: [
-    'docusaurus-plugin-sass'
+    'docusaurus-plugin-sass',
+    './spells-to-static'
   ]
 };

--- a/spells-to-static/index.js
+++ b/spells-to-static/index.js
@@ -1,0 +1,25 @@
+const { getSpells } = require('../data/spells-cjs')
+const path = require('path');
+const { writeFile } = require('fs')
+
+function spellsToStatic(context, options) {
+  return {
+    name: 'spells-to-static',
+    async loadContent() {
+      let spells = await getSpells()
+      return { spells }
+    },
+    async contentLoaded({content}) {
+      const { spells } = content
+
+      const filePath = path.join(__dirname, '../static/spells.json')
+
+      writeFile(filePath, JSON.stringify(spells), function (err) {
+        if (err) return console.log(err);
+        console.log('Saved spells to static');
+      })
+    },
+  };
+};
+
+module.exports = spellsToStatic


### PR DESCRIPTION
Esse PR adiciona um Plugin customizado no Docusaurus que obtém o conteúdo da pasta Data e transforma em arquivo JSON estático, que pode ser acessado publicamente no site do Fábulas:

`https://www.fabulasegoblins.com.br/api/spells.json`

A idéia é transformar esses dados de Filesystem em uma APIs públicas que possam ser consumidas para a criação de sistemas auxiliares do jogo.

