### PR TITLE
🐛 Patch de Balanceamento 0622 

### DIFF
--- a/data/spells/spells-kanus/ultimates/letal_shot.json
+++ b/data/spells/spells-kanus/ultimates/letal_shot.json
@@ -10,6 +10,6 @@
   "icon": "GiPocketBow",
   "element": null,
   "caption": "Materializa um Arco Mágico para desferir um único disparo preciso e mortal, causando um dano gigantesco em um alvo.",
-  "description": "<p>O Disparo Fatal sempre acerta um inimigo no seu ponto mais fraco, causando <code>TIER*(2D10+25)</code> de dano direto e causando <code>Sangramento 10*TIER</code> <b>(perda de vida por turno)</b> por 3 (três) turnos. Para acertar o ataque, você deve testar contra a Defesa Física do alvo.<br/><b>Pode atingir alvos de uma distância gigantesca.</b></p>",
+  "description": "<p>O Disparo Fatal sempre acerta um inimigo no seu ponto mais fraco, causando <code>TIER*(2D10+25)</code> de dano direto e causando <code>Sangramento 10*TIER</code> <b>(perda de vida por turno)</b> por 3 (três) turnos. Para acertar o ataque, você deve testar contra a Defesa Física do alvo.<br/><b>Pode atingir alvos de uma distância gigantesca. Apesar de testar contra Defesa Física, este poder causa dano mágico.</b></p>",
   "tags": ["grimo", "kanus", "ultimate"]
 }

--- a/data/spells/spells-roles/burn_mana.json
+++ b/data/spells/spells-roles/burn_mana.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ação: Queimar Magia",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Ativa",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você canaliza toda sua magia remanescente de volta ao universo.",
+  "description": "<p>Você gasta uma Ação Maior para drenar todos seus Pontos de Magia. Geralmente utilizado para ativar o Fôlego Mágico.</p>",
+  "tags": ["role", "caster", "encounter"]
+}

--- a/data/spells/spells-roles/collateral_damage.json
+++ b/data/spells/spells-roles/collateral_damage.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ação: Dano Colateral",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Movimento",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você se move de forma acrobática até um inimigo causando dano com sua arma.",
+  "description": "<p>Como uma ação de movimento, você pode utilizar Dano Colateral para se mover e atacar um inimigo em uma única ação. O ataque é realizado contra a Defesa física do oponente e causa <code>TIER*1d4</code> de Dano ao invés do dano da sua Arma. Se sua arma ou Grimo aumentar o seu dano causado através de uma propriedade mágica, esse dano extra poderá ser aplicado aqui.</p><p>Não pode ser realizado enquanto estiver engajado com um inimigo.</p>",
+  "tags": ["role", "carrier"]
+}

--- a/data/spells/spells-roles/defense_stance.json
+++ b/data/spells/spells-roles/defense_stance.json
@@ -1,0 +1,15 @@
+{
+  "name": "Estância de Defesa",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você entra em modo de defesa na hora certa, preparado para receber o ataque inimigo.",
+  "description": "<p>A qualquer momento antes de receber um ataque, você pode ativar a instância de Defesa para receber <code>+4</code> de Defesa (Físico e Mágico) contra o próximo ataque realizado contra você. Use essa habilidade uma vez por encontro.</p>",
+  "tags": ["role", "tank", "encounter"]
+}

--- a/data/spells/spells-roles/disengage.json
+++ b/data/spells/spells-roles/disengage.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ação: Desengajar",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Movimento",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você se afasta de um alvo hostil, criando espaço para atacar.",
+  "description": "<p>No lugar de uma ação de Movimento, você pode se afastar de um inimigo gratuitamente sem penalidades, movendo-se até <code>3</code> quadrados e realizando um ataque simultâneo com sua arma principal de longa distância. Só pode ser realizado com alvos engajados.</p>",
+  "tags": ["role", "shooter"]
+}

--- a/data/spells/spells-roles/magical_breath.json
+++ b/data/spells/spells-roles/magical_breath.json
@@ -1,0 +1,15 @@
+{
+  "name": "Fôlego Mágico",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você utiliza cada gota da sua conexão mágica para continuar canalizando poderes do seu Grimo.",
+  "description": "<p>Toda vez que você chegar em <code>0 P.M</code>, você pode rolar <code>TIER*1d6</code> para recuperar essa quantidade de P.Ms. Só pode ser usado <code>1</code> vez por encontro. Os Pontos de Magia recuperados dessa forma só podem ser usados em magias ofensivas ou que pretendem potencializar o dano do conjurador.</p>",
+  "tags": ["role", "caster", "encounter"]
+}

--- a/data/spells/spells-roles/magical_overcharge.json
+++ b/data/spells/spells-roles/magical_overcharge.json
@@ -1,0 +1,15 @@
+{
+  "name": "Sobrecarga Mágica",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você utiliza cada gota da sua conexão mágica para continuar canalizando poderes do seu Grimo.",
+  "description": "<p>A qualquer momento, sobrecarrega um poder mágico (do Grimo ou de Itens), aumentando sua área em <code>1</code>. Exemplo: Poderes em áreas quadradas de <code>1x1</code> se tornam <code>2x2</code>. Poderes que atingem <code>1</code> alvo ou ponto agora atingem <code>2</code> alvos/pontos, e poderes em linha de <code>1x4</code> se tornam <code>2x4</code>.</p><p>Não tem efeito em poderes corpo a corpo ou que se aplicam a sí mesmo.<br/>Não pode ser usado em ataques Especiais (Ultimates).</p>",
+  "tags": ["role", "caster", "encounter"]
+}

--- a/data/spells/spells-roles/power_heal.json
+++ b/data/spells/spells-roles/power_heal.json
@@ -1,0 +1,15 @@
+{
+  "name": "Cura Poderosa",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você desafia os limites da Magia para curar seus aliados com mais eficiência.",
+  "description": "<p>Uma vez por encontro, um poder de cura ou uma poção de recuperação cura um adicional de <code>TIER*1d8</code> de Dano.</p>",
+  "tags": ["role", "support", "encounter"]
+}

--- a/data/spells/spells-roles/powerful_attack.json
+++ b/data/spells/spells-roles/powerful_attack.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ataque Poderoso",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você entra em modo de defesa na hora certa, preparado para receber o ataque inimigo.",
+  "description": "<p>Use a qualquer momento para aumentar dano do seu próximo ataque em <code>TIER*d12</code>. Pode eser usado uma vez por encontro.</p>",
+  "tags": ["role", "carrier", "encounter"]
+}

--- a/data/spells/spells-roles/save_ally.json
+++ b/data/spells/spells-roles/save_ally.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ação: Salvar Aliado",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Ativa e Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Você utiliza a magia do seu Grimo para proteger um aliado com uma instância mágica.",
+  "description": "<p>A qualquer momento, apenas uma vez por encontro, você pode realizar uma Ação Extra para colocar uma instância de proteção em um alvo que previne que ele sofra <code>TIER*1d10</code> de dano no próximo ataque. Essa Ação também pode ser usada como uma Reação.</p><p>Usar <b>Salvar Aliado</b> como uma Ação não impede que você se movimente ou ataque.</p>",
+  "tags": ["role", "support", "encounter"]
+}

--- a/data/spells/spells-roles/sharp_precision.json
+++ b/data/spells/spells-roles/sharp_precision.json
@@ -1,0 +1,15 @@
+{
+  "name": "Precisão Afiada",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiNightVision",
+  "element": null,
+  "caption": "Seu treinamento lhe permite desferir um ataque preciso, que sempre acerta em cheio seu inimigo.",
+  "description": "<p>Reação: Use a qualquer momento para maximizar o valor de um único dado em um teste de ataque ou dano de um poder realizado a longa distância. Usar esta habilidade durante um ataque não resulta em um Triunfo mas pode evitar um Fracasso de ocorrer. Pode ser usado uma vez por encontro.</p><p>Caso você tenha rolado <code>1 e 20</code> no seu ataque, e tenha maximizado o Fracasso, seu teste é considerado automaticamente como um Triunfo não Épico.</p>",
+  "tags": ["role", "shooter", "encounter"]
+}

--- a/data/spells/spells-roles/taunt.json
+++ b/data/spells/spells-roles/taunt.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ação: Provocar",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Ativa",
+  "cast_distance": 7,
+  "range_amount": 1,
+  "range_type": "Alvo",
+  "icon": "GiBubbles",
+  "element": null,
+  "caption": "Você provoca seu inimigo vorazmente, fazendo com que ele seja obrigado a te atacar..",
+  "description": "Como Tanque, você pode usar uma Ação especial de Provocação. Provocar um inimigo faz com que ele receba <code>-4</code> de Ataque (Físico e Mágico) caso decida não te atacar. A Provocação só tem efeito até o próximo ataque do alvo.",
+  "tags": ["racial", "valdari"]
+}

--- a/data/spells/spells-roles/utility_initiation.json
+++ b/data/spells/spells-roles/utility_initiation.json
@@ -1,0 +1,15 @@
+{
+  "name": "Inicio Utilitário",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiBubbles",
+  "element": null,
+  "caption": "Antes mesmo de um combate iniciar, você sabe avaliar seus inimigos e se preparar para o combate de forma mais eficiente.",
+  "description": "<p>Quando um encontro iniciar, escolha um</p><ul><li>Iniciar o encontro com <code>TIER*5</code> P.M temporários.</li><li>Iniciar o encontro com <code>TIER*5</code> P.V temporários.</li><li>Iniciar o encontro com <code>+4</code> de Iniciativa</li><li>Iniciar o encontro com <code>+4</code> de Bônus de Ataque.</li><li>Iniciar o encontro com <code>+4</code> de Bônus de Defesa.</li>",
+  "tags": ["role", "utility"]
+}

--- a/data/spells/spells-roles/utility_manouver.json
+++ b/data/spells/spells-roles/utility_manouver.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ação: Manobra Utilitária",
+  "magic_cost": "0 P.M",
+  "duration_time": "0",
+  "attack_logic": null,
+  "action_type": "Ação e Reação",
+  "cast_distance": null,
+  "range_amount": null,
+  "range_type": null,
+  "icon": "GiBubbles",
+  "element": null,
+  "caption": "Sua flexibilidade te permite se adaptar a um combate e realizar uma manobra utilitária especial.",
+  "description": "<p>Uma vez por encontro, e a qualquer momento, escolha um:</p><ul><li>Durante seu turno, receba <code>+4</code> de movimento.</li><li>Durante seu turno, aumente sua alcance de ataque em <code>+2</code>.</li><li>Durante seu turno, aumente o dano causado no seu próximo ataque em <code>TIER*5</code></li><li>Forneça <code>+2</code> de Ataque ou Defesa a um aliado. (especificar se é Físico ou Mágico)</li>",
+  "tags": ["role", "utility", "encounter"]
+}

--- a/data/spells/spells/extra_attribute.json
+++ b/data/spells/spells/extra_attribute.json
@@ -10,6 +10,6 @@
   "icon": "GiUpgrade",
   "element": null,
   "caption": "Goblins são muito habilidosos, e parecem ter uma enorme disposição para aprender muitas coisas diferentes.",
-  "description": "Ao criar um Goblin, receba 2 pontos extra de Atributos para distribuir como quiser.",
+  "description": "Ao criar um Goblin, receba 1 pontos extra de Atributo para distribuir como quiser. Além disso, todos os atributos com valor -1 passam a ser 0. Nenhum atributo pode superar o valor de +4 como resultado dessa habilidade racial.",
   "tags": ["racial", "goblin"]
 }

--- a/data/spells/spells/initial_mount.json
+++ b/data/spells/spells/initial_mount.json
@@ -10,6 +10,6 @@
   "icon": "GiHorseshoe",
   "element": null,
   "caption": "Quem preza os próprios joelhos sabe quando pode ser perigoso viajar distancias longas a pé.",
-  "description": "<p>Você inicia o jogo com uma Montaria Inicial (escolhas: Cromodon, Bungan).</p>",
+  "description": "<p>Você inicia o jogo com uma Montaria Inicial (escolhas: Cromodon, Bungan). Sua montaria inicial possui <b>(TIER*15 P.V)</b> mas não pode ser controlada ou usada para atacar em um combate.</p><p>Estar montado durante um combate fornece a você +2 Pontos de Movimento por turno.</p><p>Inimigos podem escolhar atacar a montaria ao invés de te atacar. Caso isso aconteça, você pode rolar a defesa normalmente contra o ataque, porém não pode usar seus modificadores de defesa. Por padrão, as montarias possuem +0 de Defesa.</p><p>Fora de um combate, as montarias proporcionam o dobro de velocidade de viajem comparado com personagens desmontados.</p>",
   "tags": ["cultural", "children-of-plains"]
 }

--- a/docs/10-the-guide/preparing-combats.md
+++ b/docs/10-the-guide/preparing-combats.md
@@ -94,6 +94,8 @@ Essa expectativa vai te ajudar a entender como os seus Personagens podem progred
 
 Esses itens geralmente vão fornecer aos Personagens **valores de ataque e de defesa adicionais**, e por isso, precisam ser considerados na hora de criarmos novos inimigos para o Universo do **Fábulas & Goblins**.
 
+Inicialmente, cada atributo de Personagem **pode variar entre -1 e +4**, então você precisa considerar que um personagem **Tier 1** com uma **Espada +2** tecnicamente já pode possuir **+6 de Ataque**, o que permite que ele acerte facilmente os inimigos desse Tier.
+
 Todos os inimigos que você encontrará em nosso **Bestiário** foram criados com essa expectativa em mente.
 
 | Tier | Ataque Físico            | Ataque Mágico | Defesa Física | Defesa Mágica |
@@ -103,11 +105,16 @@ Todos os inimigos que você encontrará em nosso **Bestiário** foram criados co
 | Tier 3 (Níveis 11 a 15)   | Entre +4 e +8            | Entre +4 e +8            | Entre +4 e +8            | Entre +4 e +8            |
 | Tier 4 (Níveis 16 a 20)   | Entre +8 e +16           | Entre +8 e +16           | Entre +8 e +16           | Entre +8 e +16           |
 
-Isso significa que, ao distribuir **itens mágicos** aos jogadores, você poderá usar a tabela acima para entender os limites esperados e evitar que os personagens se tornem muito mais fortes que os inimigos do nosso bestiário.
+Personagens de **Tier 4** podem possuir até **+16 de Bônus de Ataque**, isso porquê inimigos poderosos de Tier 4 como **Knerotracos** podem possuir **35 de Defesa** ou até mais que isso.
+No caso de um **Knerotraco de Fogo** por exemplo, jogadores com +4 de Atributo e +16 de Bônus de Ataque precisariam tirar **15 ou mais no Dado** caso queiram superar a defesa dele. *(4 + 16 + 15 = 35)*
 
-Por exemplo, entregar uma **Espada +4** (Ataque Físico +4) a um **Personagem Nível 3** pode tornar ele muito forte em comparação aos inimigos desse Tier, já entregar uma **Espada +4** para um personagem **Nível 16** pode ser inferior ao nível de inimigos que eles enfrentarão.
+Logo, ao distribuir **itens mágicos** aos jogadores, você poderá usar a tabela acima para entender os **limites esperados** e **evitar** que os personagens se tornem **muito mais fortes** que os **inimigos do nosso bestiário**.
 
-Logicamente, essa regra não é tão relevante caso você esteja criando seus próprios inimigos!
+Por exemplo, entregar uma **Espada +4** (Ataque Físico +4) a um **Personagem Nível 3** pode tornar ele muito forte em comparação aos inimigos desse Tier, já entregar uma **Espada +4** para um personagem **Nível 16** pode ser **inferior** ao nível de inimigos que eles enfrentarão.
+
+:::note
+Apesar de **não recomendarmos**, vale dizer que essa regra é **irrelevante** caso você esteja **criando seus próprios inimigos** e fazendo seu próprio **balanceamento**!
+:::
 
 ## 2. Criando Combates
 

--- a/docs/2-sheet-creation/attack-points.md
+++ b/docs/2-sheet-creation/attack-points.md
@@ -1,25 +1,25 @@
 ---
 id: attack-points
-title: Pontos de Ataque Físico
+title: Pontos de Ataque Principal
 slug: /2-sheet-creation/attack-points
 ---
 
 ![Pontos de Ataque](https://fabulas-e-goblins-book.s3-us-west-2.amazonaws.com/criando-seu-personagem/pontos-de-ataque-01.png)
 
 A **melhor defesa** é o **ataque**, certo? *Ou pelo menos é o que dizem por ai*.<br/>
-No *Fábulas & Goblins*, **cada jogador** possui especificado em sua Ficha um valor de **Pontos de Ataque**, que é utilizado tanto para **ataques físicos** Corpo a Corpo *(ex: Espadas)*, quanto **ataques à distância** *(ex Arco e Flecha)*.
+No *Fábulas & Goblins*, **cada jogador** possui especificado em sua Ficha um valor de **Ataque Principal**, que é utilizado tanto para **ataques corpo a corpo** *(ex: Espadas)*, quanto **ataques à distância** *(ex Arco e Flecha)* e armas de **natureza mágica** como *Orbes e Livros*
 
-Os **Pontos de Ataque** são usados sempre que você **declara uma ação de ataque físico** a um inimigo, e ele será sempre **somado ao resultado do dado de ataque (D20)** para decidir seu sucesso.
+O **Ataque Principal** é usado sempre que você **declara uma ação de ataque com armas** a um inimigo, e ele será sempre **somado ao resultado dos dados de ataque (2d20)** para decidir seu sucesso.
 
-Quando dizemos **Ataque Físico**, nos referimos a qualquer ataque feito com **Armas ou Punho** sem utilizar magias.
+Quando dizemos **Ataque Principal**, nos referimos a qualquer ataque feito com **Armas ou Punho** sem utilizar **Poderes Mágicos**.
 
-Isso porquê no *Fábulas & Goblins*, **ataques mágicos** podem ter sua própria fórmula de ataque, que varia entre **Ataques Elementais**, **Ataques de Reação**, entre outros.
+Isso porquê no *Fábulas & Goblins*, **Poderes Mágicos** podem ter sua própria **fórmula de ataque**, que varia entre **Ataques Elementais**, **Ataques de Reação**, entre outros.
 
-Se quiser saber mais como **Atacar durante o combate**, temos um Capítulo específico para isso, na sessão [Regras de Jogo: Atacando durante o Combate](/docs/7-game-rules/old/attacking-during-combat).
+Se quiser saber mais como **Atacar durante o combate**, temos um Capítulo específico para isso, na sessão [Regras de Jogo: Atacando durante o Combate](/docs/9-combat-rules/physical-combat).
 
 ## Calculando seus Pontos de Ataque
 
-Ao criar um personagem, você deverá calcular os seus *Pontos de Ataque* através da seguinte fórmula:
+Ao criar um personagem, você deverá calcular o seu *Ataque Principal* através da seguinte fórmula:
 
 ![Formula-PA-2.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cad1905d1-e718-4caa-a828-dc77462ed928.jpg)
 
@@ -30,6 +30,8 @@ Esse Atributo é **descrito na própria arma**.<br/>
 
 Logo, a arma que você utilizar definirá como você deverá calcular seu ataque.<br/>
 Portanto lembre-se, **sempre que trocar de arma**, deve verificar se existe a necessidade de **revisar seu ataque**.
+
+Caso você utilize duas armas, ou um escudo, pode calcular o ataque dele e marcar no campo da Ficha **"Ataque Secundário"**.
 
 ### Ataque da Arma
 
@@ -47,3 +49,13 @@ Mirana está equipando uma **Orbe Rúnica +2 (Bonus de Ataque)**. O Atributo da 
 <br/><br/>Portanto, ao atacar um inimigo com <b>16 Pontos de Defesa</b>, Mirana deverá rolar um D20 e <b>somar +4</b> ao seu resultado. Neste caso, ela <b>apenas acertará</b> o inimigo se <b>tirar pelo menos 12 no Dado</b> (pois <code>12 + 4 >= 16</code>)
 
 :::
+
+### Armas Físicas e Mágicas
+
+A maioria das armas possuem natureza de **ataque físico**, como Espadas, Machados, e Flechas comuns. Então quando vemos a notação **Espada +1**, estamos nos referindo a uma Espada que causa *dano físico* e **aumenta em +1 o seu Ataque Físico**.
+
+Porém, algumas **armas especiais** disparam **projeteis mágicos**, como é o caso das **Orbes**, **Cajados** e **Livros**. Essas armas, para efeitos de jogo são sempre categorizadas como **Armas Mágicas**, pois a capacidade de emitir **projeteis de natureza mágica** só é possível quando a magia se encontra **armazenada** dentro do item.
+
+Dessa forma, quando dizemos **Orbe +2**, estamos nos referindo a uma **Orbe** que causa *dano mágico* e **aumenta em +2 o seu Ataque Mágico**.
+
+Essa notação pode ser confusa a princípio, mas todas as Armas descritas em nosso Compendium possuirão uma **marcação especial** para dizer se são **armas de dano físico ou mágico**.

--- a/docs/2-sheet-creation/defense-points.md
+++ b/docs/2-sheet-creation/defense-points.md
@@ -14,7 +14,7 @@ Assim como os **Pontos de Vida** e **Magia**, os **Pontos de Defesa** também au
 
 Ao criar o seu personagem, você deve calcular seus **Pontos de Defesa Física** *(D.F)* com a seguinte fórmula:
 
-![Formula-PD-2.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C40ceadaf-7222-4994-b022-b4d968d0023c.jpg)
+![Formula-PD-2.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cba7f5e1f-b9bc-4dbf-8d55-bb669ccda1dc.jpg)
 
 Os Pontos de Defesa **entram em jogo** sempre que seu personagem for **atacado fisicamente**. Nesses momentos, você deverá deverá rolar um D20 e **Somar seus Pontos de Defesa**.
 
@@ -27,8 +27,8 @@ Vamos falar um pouco sobre isso.
 
 No jogo, existem várias formas de conseguir aumentar seus Pontos de Defesa.
 
-- Adquirindo pontos de **Força ou Resiliência**.
-- Treinando Poderes no Grimo que **aumentam Defesa** ([Introdução aos Grimos](/docs/4-grimos-and-spells/introduction)).
+- Adquirindo pontos do atributo **Resiliência**.
+- Treinando Poderes no Grimo que **aumentam Defesa Física** ([Introdução aos Grimos](/docs/4-grimos-and-spells/introduction)).
 - Adquirindo [Equipamentos melhores](/docs/13-appendix/types-of-armor) *(ou até escudo e outros acessórios de defesa)*.
 
 :::tip Importante

--- a/docs/2-sheet-creation/defense-points.md
+++ b/docs/2-sheet-creation/defense-points.md
@@ -14,7 +14,7 @@ Assim como os **Pontos de Vida** e **Magia**, os **Pontos de Defesa** também au
 
 Ao criar o seu personagem, você deve calcular seus **Pontos de Defesa Física** *(D.F)* com a seguinte fórmula:
 
-![Formula-PD-2.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C213e52ab-0dd6-4c66-a326-41309384de62.jpg)
+![Formula-PD-2.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C40ceadaf-7222-4994-b022-b4d968d0023c.jpg)
 
 Os Pontos de Defesa **entram em jogo** sempre que seu personagem for **atacado fisicamente**. Nesses momentos, você deverá deverá rolar um D20 e **Somar seus Pontos de Defesa**.
 
@@ -27,7 +27,7 @@ Vamos falar um pouco sobre isso.
 
 No jogo, existem várias formas de conseguir aumentar seus Pontos de Defesa.
 
-- Adquirindo pontos de **Agilidade ou Resiliência** nos [Níveis Especiais](/docs/7-game-rules/old/special-levels).
+- Adquirindo pontos de **Força ou Resiliência**.
 - Treinando Poderes no Grimo que **aumentam Defesa** ([Introdução aos Grimos](/docs/4-grimos-and-spells/introduction)).
 - Adquirindo [Equipamentos melhores](/docs/13-appendix/types-of-armor) *(ou até escudo e outros acessórios de defesa)*.
 

--- a/docs/2-sheet-creation/magic-attack-points.md
+++ b/docs/2-sheet-creation/magic-attack-points.md
@@ -19,6 +19,8 @@ Ao criar um personagem, você deverá calcular o seu *Ataque Mágico* (A.M) atra
 
 ### Bônus de Ataque
 
+O primeiro **Bônus de Ataque** que você deve considerar é aquele que vêm da sua Arma. Lembre-se que somente o Bônus de Armas de **Natureza Mágica** (que causam dano mágico) podem ser considerados aqui. O que significa que seu **Machado +2** provavelmente não vai adicionar nenhum Bônus.
+
 Algumas escolhas de Poderes e de Papel de Jogo podem ajudar a aumentar o Ataque Mágico. O Papel do Conjurador por exemplo fornece **+1 de Bônus** contra **Ataques Mágicos**.
 
 Algumas Culturas como os **Filhos do Orvalho** e os **Filhos de Arcádia** também podem fornecer melhorias de **Intelecto**, que por sua vez afetam o modificador de **Ataque Mágico**.
@@ -26,3 +28,13 @@ Algumas Culturas como os **Filhos do Orvalho** e os **Filhos de Arcádia** tamb�
 :::note Dica
 Para jogadores que não possuem uma construção especializada em Intelecto, existem Armaduras especiais que podem fornecer Bônus de Intelecto ou de **Pontos de Ataque Mágico** diretamente.
 :::
+
+### Armas Físicas e Mágicas
+
+A maioria das armas possuem natureza de **ataque físico**, como Espadas, Machados, e Flechas comuns. Então quando vemos a notação **Espada +1**, estamos nos referindo a uma Espada que causa *dano físico* e **aumenta em +1 o seu Ataque Físico**.
+
+Porém, algumas **armas especiais** disparam **projeteis mágicos**, como é o caso das **Orbes**, **Cajados** e **Livros**. Essas armas, para efeitos de jogo são sempre categorizadas como **Armas Mágicas**, pois a capacidade de emitir **projeteis de natureza mágica** só é possível quando a magia se encontra **armazenada** dentro do item.
+
+Dessa forma, quando dizemos **Orbe +2**, estamos nos referindo a uma **Orbe** que causa *dano mágico* e **aumenta em +2 o seu Ataque Mágico**.
+
+Essa notação pode ser confusa a princípio, mas todas as Armas descritas em nosso Compendium possuirão uma **marcação especial** para dizer se são **armas de dano físico ou mágico**.

--- a/docs/2-sheet-creation/magic-defense.md
+++ b/docs/2-sheet-creation/magic-defense.md
@@ -14,21 +14,20 @@ Habilidades e equipamentos também podem influenciar nos seus Pontos de **Defesa
 
 Ao criar o seu personagem, você deve calcular seus Pontos de **Defesa Mágica (D.M)** com a seguinte fórmula:
 
-![Formula-PDM.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Ccd4d229b-c8f4-4c26-ba27-483d75ae20ef.jpg)
+![Formula-PDM.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cbfd65dfd-1527-4b9d-ab34-6ff5c1dfbc8f.jpg)
 
 Os **Pontos de Defesa Mágica** entram em jogo sempre que seu personagem for atacado por algum **poder de origem mágica ou elemental**. Nesses momentos, você deverá deverá **rolar um D20** e somar o resultado do dado com o **valor deste cálculo**.
 
-O Valor final deve ser *superior* à **Potência do Ataque Mágico** recebido. Logo, se você possui +2 de **Defesa Mágica** e está sofrendo um **Ataque de Potência 18**, deve tirar pelo menos 16 no Dado para superar ou desviar do ataque.
+O Valor final deve ser *superior* à **Potência do Ataque Mágico** recebido. Logo, se você possui +2 de **Defesa Mágica** e está sofrendo um **Ataque de Potência 18**, deve tirar pelo menos **16 no Dado** para superar ou desviar do ataque.
 
 Mas não se preocupe, pois conforme a evolução do seu personagem, este valor também poderá ser aumentado.
 Vamos falar um pouco sobre isso.
-
 
 ## Aumentando seus pontos de Defesa Mágica
 
 No jogo, existem várias formas de aumentar sua **Defesa Mágica**.
 
-- Adquirindo pontos de **Elo Mágico ou Espírito** nos [Níveis Especiais](/docs/7-game-rules/old/special-levels).
+- Adquirindo pontos de **Espírito** nos [Níveis Especiais](/docs/7-game-rules/old/special-levels).
 - Treinando Poderes no Grimo que **aumentam Defesa Mágica** ([Introdução aos Grimos](/docs/4-grimos-and-spells/introduction)).
 - Adquirindo [Equipamentos melhores](/docs/13-appendix/types-of-armor) *(a exemplo de implementos e outros itens mágicos)*.
 

--- a/docs/3-species/introduction.md
+++ b/docs/3-species/introduction.md
@@ -1,7 +1,0 @@
----
-id: species-introduction
-title: Escolhendo sua espécie
-slug: /3-species/species-introduction
----
-
-Esta página está em construção e encontra-se indisponível.

--- a/docs/4-grimos-and-spells/alluras-orb.md
+++ b/docs/4-grimos-and-spells/alluras-orb.md
@@ -180,10 +180,10 @@ As descobertas de **Drako** no primeiro Século após o Blecaute teriam salvo se
 
 Você pode escolher entre duas armas iniciais:
 
-| Imagem | Nome da Arma | Dano | Descrição | Durabilidade |
-| ------ | ------------ | ---- | --------- | ------------ |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C176956f9-2502-452c-963e-181799550369.png" width="80" /> | Orbe do Iniciante + 0 | D4 + 4 | Orbe inicial do Aventureiro, ataca a longa distância* com um feixe não elemental | 3 Cargas |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cc8623aa6-2402-42d2-8633-faa7bd679ddd.png" width="80" /> | Cetro do Iniciante + 0 | D6 + 4 | Cetro inicial do Aventureiro, ataque corpo-a-corpo. | 3 Cargas |
+| Imagem | Nome da Arma | Tipo Dano | Dano | Descrição | Durabilidade | Atributo   |
+| ------ | ------------ | --------- | ---- | --------- | ------------ | ---------- |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C176956f9-2502-452c-963e-181799550369.png" width="80" /> | Orbe do Iniciante + 0 | Mágico | D4 + 4 | Orbe inicial do Aventureiro, ataca a longa distância* com um feixe não elemental | 3 Cargas | Elo Mágico |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cc8623aa6-2402-42d2-8633-faa7bd679ddd.png" width="80" /> | Cetro do Iniciante + 0 | Físico | D6 + 4 | Cetro inicial do Aventureiro, ataque corpo-a-corpo. | 3 Cargas | Inteligência |
 
 **A distância padrão para Armas de Alcance é de 6 quadrados.*
 

--- a/docs/4-grimos-and-spells/eye-of-kanus.md
+++ b/docs/4-grimos-and-spells/eye-of-kanus.md
@@ -195,12 +195,12 @@ Foi apenas após diversas incursões bem sucedidas que `Duric` e seus aliados de
 
 ## Armas Iniciais
 
-Você pode escolher entre duas armas iniciais: 
+Você pode escolher entre duas armas iniciais:
 
-| Imagem | Nome da Arma | Dano | Descrição | Durabilidade |
-| ------ | ---- | --------- | ------------ | ------------ |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C67068ed3-ae88-4391-b3dc-a3b8529399d0.PNG" width="80" /> | Arco do Iniciante + 0 | D8 + 3 | Arco inicial do Aventureiro*, bem simples e medianamente construído. Flechas normais são "infinitas". | 3 Cargas |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C06a7be0e-8191-4a21-92f7-8a2512083d9e.png" width="80" /> | Espada do Iniciante + 0 | D10 + 2 | Adaga inicial do Aventureiro, bem simples e suporta poucos cortes. | 3 Cargas |
+| Imagem | Nome da Arma | Tipo de Dano | Dano | Descrição | Durabilidade | Atributo |
+| ------ | ---- | --------- | ------------ | ------------ | ------| ----- |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C67068ed3-ae88-4391-b3dc-a3b8529399d0.PNG" width="80" /> | Arco do Iniciante + 0 | Físico | D8 + 3 | Arco inicial do Aventureiro*, bem simples e medianamente construído. Flechas normais são "infinitas". | 3 Cargas | Sobrevivência |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C06a7be0e-8191-4a21-92f7-8a2512083d9e.png" width="80" /> | Espada do Iniciante + 0 | Físico | D10 + 2 | Adaga inicial do Aventureiro, bem simples e suporta poucos cortes. | 3 Cargas | Agilidade |
 
 **A distância padrão para Armas de Alcance é de 6 quadrados.*
 

--- a/docs/4-grimos-and-spells/giurads-crest.md
+++ b/docs/4-grimos-and-spells/giurads-crest.md
@@ -75,39 +75,26 @@ O Tutor é uma pessoa da sua história de vida que gerou sua indicação para a 
 A nomeação no primeiro momento pode ser tão simples como: Meu Tutor chama-se "Fulano da Silva". O nome do Tutelado deve estar anotado na sua Ficha de Personagem para referência futura do Narrador.
 *Não é necessário que a história do Tutor seja explicada nesse primeiro momento, mas com certeza se você tiver uma explicação, será melhor!*<br/>
 
-### 2. **Escolher uma Especialização inicial de Arma**
-
-Essa especialização deve ser adicionada a sua ficha, e lhe garantirá um Bônus de +1 em todos ataques utilizando esse tipo de arma. (O bônus também pode se aplicar aos poderes, caso o poder cite sua arma como canalização do poder).
-
-Esse bônus sinaliza um treinamento inicial para se movimentar e se equilibrar utilizando esse tipo de arma.*<br/>
-Dentre as categorias de armas, estão:
-  - Espadas
-  - Machados
-  - Martelos/Malhos
-  - Clavas/Maças
-  - Bastões
-  - Armas de Haste
-  - Escudos
-
-**A escolha da Especialização se aplica tanto para Armas de Uma Mão ou de Duas Mãos.**
-
-:::note Armas e suas Categorias
-No mundo real, o combate com tipos diferentes de espadas pode afetar completamente o tipo de treinamento que você precisa para utilizar uma certa arma.
-
-Aqui no Fábulas, não temos a intenção de ser um sistema *Simulacionista*, e para efeito de simplificação, compactamos o bônus de especialização em grandes grupo de armas, como descrevemos acima, justamente para tornar a criação do personagem mais fácil e objetiva.
-
-Caso o Narrador prefira entrar no detalhe e decidir por exemplo que personagens com treinamento em **Scimitarras** não podem receber o mesmo bônus ao utilizar **Espadas de Esgrima**, não tem problema, fica a cargo do grupo decidir quais regras fazem mais sentido para o treinamento de especialização.
-
-Nossa sugestão oficial é que se utilizem as categorias genéricas, mas nada impede o grupo de trabalhar aspectos mais detalhados desse treinamento.<br/>
-De fato, em determinadas aventuras, a depender do contexto, esse tipo de decisão pode ser bastante interessante.
-:::
-
-### 3. Escolher seus Poderes Iniciais
+### 2. Escolher seus Poderes Iniciais
 
 A menos que outra regra diga o contrário, você deverá:
 
 - Escolher 2x (dois) Poderes do Tier 1.
 - Escolher 1x (um) Poder Especial.
+
+## Folego de Herói
+
+Sua vontade em vencer seus obstáculos seria indescritível para qualquer um sem sua garra e motivação.
+
+Além disso, **Adeptos de Giurad** são treinados a ferro e fogo para circunstâncias letais onde pode não haver esperança. Por isso, esses guerreiros aprendem desde o início que o mundo é cruel, e só depende deles se tornarem a própria faísca da esperança.
+
+O Folego de Herói garante que, uma vez por dia, sempre que você chegar a **0 P.V e for abatido**, faça um **Teste de Resiliência**. Se for bem sucedido, você se levanta **após no mínimo 3 turnos** com apenas **1 P.V** para viver e lutar mais uma vez.
+
+**Você pode escolher se levantar em qualquer ordem da iniciativa.**
+
+Antes de se levantar, como uma ação livre de puro metajogo, você pode narrar os pensamentos ou visões que te levaram a se levantar epicamente contra a escuridão e lutar mais uma vez.
+
+Essa ação, se bem sucedida, **não gerará um Trauma** para o Personagem.
 
 ## Interpretando um Adepto de Giurad
 
@@ -116,7 +103,7 @@ Eles são vistos pelos outros como uma espécie de **Cavaleiro**, cujos objetivo
 
 A honra desse privilégio é muito bem vista em civilizações do mundo todo, pois os **Adeptos de Giurad** sacrificam suas pretenções para defender aqueles que mantém o equilíbrio do mundo.
 
-Politicamentee, a **Academia de Giurad** é aliado de grandes Reinos, sendo cada academia individual geralmente associada a um único reino ou império.
+Politicamente, a **Academia de Giurad** é aliado de grandes Reinos, sendo cada academia individual geralmente associada a um único reino ou império.
 
 Os **Adeptos** portanto, são Cavaleiros leais, que possuem objetivos claros e são muitas vezes avistados como Guarda-Costas de Elite de entidades importante no mundo, como Imperadores e Augúrios.
 
@@ -140,10 +127,10 @@ Uma das grandes virtudes que se destacam na criação do Grimo é sua criativida
 
 Você pode escolher entre duas armas iniciais:
 
-| Imagem | Nome da Arma | Dano | Descrição | Durabilidade |
-| ------ | ------------ | ---- | --------- | ------------ |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cd2270d31-e7bf-4168-a90d-bcf772514e1d.png" width="80" /> | Machado do Iniciante + 0 | D12 + 3 | Machado inicial do Aventureiro, bem simples, e suporta poucos cortes. | 3 Cargas |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cc728c292-e23a-4e87-a070-a3ee81e17dde.png" width="80" /> | Espada do Iniciante + 0 | D12 + 3 | Espada inicial do Aventureiro, bem simples, e suporta poucos cortes. | 3 Cargas |
+| Imagem | Nome da Arma | Tipo de Dano | Dano | Descrição | Durabilidade | Atributo |
+| ------ | ------------ | ---- | --------- | ------------ | -------- | --------|
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cd2270d31-e7bf-4168-a90d-bcf772514e1d.png" width="80" /> | Machado do Iniciante + 0 | Físico | D12 + 3 | Machado inicial do Aventureiro, bem simples, e suporta poucos cortes. | 3 Cargas | Resiliência |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cc728c292-e23a-4e87-a070-a3ee81e17dde.png" width="80" /> | Espada do Iniciante + 0 | Físico | D12 + 3 | Espada inicial do Aventureiro, bem simples, e suporta poucos cortes. | 3 Cargas | Força |
 
 ## Poderes do Grimo
 

--- a/docs/4-grimos-and-spells/giurads-crest.md
+++ b/docs/4-grimos-and-spells/giurads-crest.md
@@ -88,11 +88,11 @@ Sua vontade em vencer seus obstáculos seria indescritível para qualquer um sem
 
 Além disso, **Adeptos de Giurad** são treinados a ferro e fogo para circunstâncias letais onde pode não haver esperança. Por isso, esses guerreiros aprendem desde o início que o mundo é cruel, e só depende deles se tornarem a própria faísca da esperança.
 
-O Folego de Herói garante que, uma vez por dia, sempre que você chegar a **0 P.V e for abatido**, faça um **Teste de Resiliência**. Se for bem sucedido, você se levanta **após no mínimo 3 turnos** com apenas **1 P.V** para viver e lutar mais uma vez.
+O Folego de Herói garante que, uma vez por dia, sempre que você chegar a **0 P.V e for abatido**, faça um **Teste de Resiliência**. Se for bem sucedido, você se levanta **após 1 turno** com apenas **1 P.V** para viver e lutar mais uma vez.
 
 **Você pode escolher se levantar em qualquer ordem da iniciativa.**
 
-Antes de se levantar, como uma ação livre de puro metajogo, você pode narrar os pensamentos ou visões que te levaram a se levantar epicamente contra a escuridão e lutar mais uma vez.
+Antes de se levantar, como uma **ação livre de interpretação**, você pode narrar os pensamentos ou visões que te levaram a se levantar epicamente contra a escuridão e lutar mais uma vez.
 
 Essa ação, se bem sucedida, **não gerará um Trauma** para o Personagem.
 

--- a/docs/4-grimos-and-spells/lunns-jewel.md
+++ b/docs/4-grimos-and-spells/lunns-jewel.md
@@ -148,10 +148,10 @@ Após o Blecaute, muitos Terrores deixaram o manto da Escuridão para encobrir a
 
 Você pode escolher entre duas armas iniciais:
 
-| Imagem | Nome da Arma | Dano | Descrição | Durabilidade |
-| ------ | ------------ | ---- | --------- | ------------ |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C28df9fc9-21e5-4a87-a8fb-afa90f6640e7.PNG" width="80" /> | Cajado do Iniciante + 0 | D6 + 3 | Cajado inicial do Aventureiro, ataca a longa distância* com um feixe não elemental | 3 Cargas |
-| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C203894a8-17e4-49b8-b22b-1de705ebb086.PNG" width="80" /> | Cruz do Iniciante + 0 | D8 + 4 | Cruz inicial do Aventureiro, ataque corpo-a-corpo, já vem benzida. | 3 Cargas |
+| Imagem | Nome da Arma | Tipo do Dano | Dano | Descrição | Durabilidade | Atributo |
+| ------ | ------------ | ---- | --------- | ------------ | -------- | ---- |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C28df9fc9-21e5-4a87-a8fb-afa90f6640e7.PNG" width="80" /> | Cajado do Iniciante + 0 | Mágico | D6 + 3 | Cajado inicial do Aventureiro, ataca a longa distância* com um feixe não elemental | 3 Cargas | Elo Mágico |
+| <img src="https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C203894a8-17e4-49b8-b22b-1de705ebb086.PNG" width="80" /> | Cruz do Iniciante + 0 | Físico | D8 + 4 | Cruz inicial do Aventureiro, ataque corpo-a-corpo, já vem benzida. | 3 Cargas | Espírito |
 
 **A distância padrão para Armas de Alcance é de 6 quadrados.*
 

--- a/docs/5-roles/carrier.md
+++ b/docs/5-roles/carrier.md
@@ -2,7 +2,15 @@
 id: roles-adventurer
 title: Carregador
 slug: /5-roles/roles-adventurer
+image: https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C7fffe2b9-0752-49af-a86a-f5a956ea84bf.jpg
 ---
+
+import { SpellFromJson } from './../../src/components/skill_block/index'
+
+import collateral_damage from './../../data/spells/spells-roles/collateral_damage.json'
+import powerful_attack from './../../data/spells/spells-roles/powerful_attack.json'
+
+![Quer saber como se tornar uma verdadeira máquina de destruição? Conheça os Carregadores!](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C7fffe2b9-0752-49af-a86a-f5a956ea84bf.jpg)
 
 Se você é daqueles que não se importa em correr riscos se o objetivo for causar o maior dano, o Papel Carregador é pra você!
 Como o próprio nome diz, o Papel do Carregador possui este nome porque esses personagens geralmente "Carregam" o time em direção a vitória.
@@ -48,7 +56,7 @@ Ao escolher esse Papel, você terá uma boa base de Pontos de Vida, e isso lhe p
     </tr>
     <tr>
       <td>Proficiência Armas</td>
-      <td>Força ou Resiliência</td>
+      <td>Força ou Agilidade</td>
     </tr>
     <tr>
       <td>Pontos de Vida por Nível</td>
@@ -58,10 +66,11 @@ Ao escolher esse Papel, você terá uma boa base de Pontos de Vida, e isso lhe p
       <td>Pontos de Magia por Nível</td>
       <td>+2/+4/+4/+6</td>
     </tr>
-    <tr>
-      <td>Bônus de Ataque Corpo-a-Corpo</td>
-      <td>+1</td>
-    </tr>
   </tbody>
 </table>
 
+## Poderes do Papel
+
+<SpellFromJson expanded={false} spellData={collateral_damage} />
+
+<SpellFromJson expanded={false} spellData={powerful_attack} />

--- a/docs/5-roles/caster.md
+++ b/docs/5-roles/caster.md
@@ -2,7 +2,16 @@
 id: roles-arcanist
 title: Conjurador
 slug: /5-roles/roles-arcanist
+image: https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C60f053b3-d44d-4d99-acf0-131ce11f8717.jpg
 ---
+
+import { SpellFromJson } from './../../src/components/skill_block/index'
+
+import magical_breath from './../../data/spells/spells-roles/magical_breath.json'
+import burn_mana from './../../data/spells/spells-roles/burn_mana.json'
+import magical_overcharge from './../../data/spells/spells-roles/magical_overcharge.json'
+
+![Quer saber o que um Conjurador pode fazer no jogo? Vêm que a gente mostra!](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C60f053b3-d44d-4d99-acf0-131ce11f8717.jpg)
 
 Conjuradores são carregadores mágicos. Geralmente dependem de um vínculo forte com a Magia, pois seus poderes costumam utilizar muito mais Conexão mágica do que outros Papeis de Jogo.
 
@@ -57,9 +66,13 @@ Ao escolher esse Papel, você terá uma boa base de Pontos de Magia, e isso lhe 
       <td>Pontos de Magia por Nível</td>
       <td>+4/+4/+8/+8</td>
     </tr>
-    <tr>
-      <td>Bônus de Ataque Mágico</td>
-      <td>+1</td>
-    </tr>
   </tbody>
 </table>
+
+## Poderes do Papel
+
+<SpellFromJson expanded={false} spellData={burn_mana} />
+
+<SpellFromJson expanded={false} spellData={magical_breath} />
+
+<SpellFromJson expanded={false} spellData={magical_overcharge} />

--- a/docs/5-roles/introduction.md
+++ b/docs/5-roles/introduction.md
@@ -14,27 +14,24 @@ Em Sistemas de RPG tradicionais, as Classes ditam vários aspectos do personagem
 - Rótulos de Interpretação (Bárbaros são brutos, Bardos são carismáticos, e por ai vai)
 - Curva de evolução (As Classes geralmente possuem uma base de Pontos de Vida que ganham por nível)
 - Proficiências de Armas
-- Habilidades (Cada classe possui suas habilidades)
+- Habilidades e Poderes (Cada classe possui suas habilidades)
 
 Enquanto é inegável que esse é um sistema é simples de digerir, ele também impõe muitas pequenas restrições que podem acabar dificultando a criação de personagens "fora da curva".
 
-Por isso, no Fábulas, logo no começo tomamos a decisão de remover o conceito de "Classes" completamente do jogo, substituindo elas pelo conceito de "Papeis"
+Por isso, no Fábulas, logo no começo tomamos a decisão de remover o conceito de "Classes" completamente do jogo, substituindo elas por diversos conceitos independentes, incluindo o conceito de "Papeis".
 
 :::note Classes
 É claro que dentro do mundo das Terras Místicas, esses Rótulos ou Designações de Classe existem normalmente, pois existem academias específicas que treinam Sacerdotes, Cavaleiros, Arcanistas, Fortunos e todo os tipos de rótulos de classe que você pode imaginar.
-A única diferença é que essas "Classes" se restringem ao mundo de jogo, e passam a não representar mais uma "Escolha" na sua ficha.
+A única diferença é que esses termos se restringem ao mundo de jogo, e não representam mais uma escolha na sua ficha.
 :::
 
 ## Como eu escolho meu Papel?
 
-O Papel é uma escolha que você faz na construção da sua ficha que dita como será a progressão mecânica do seu personagem. Ele irá ganhar mais pontos de vida? Terá um ataque base superior? Se movimentará mais pelo campo de batalha?
+A escolha do Papel define como será a **progressão mecânica** do seu Personagem conforme ele passar de nível. Ele irá ganhar **mais pontos de vida**? Terá um **ataque** superior? Se **movimentará mais** pelo campo de batalha? Tudo isso é definido quando você escolhe um Papel de jogo.
 
-Todas essas caracteríscas são esclarecidas pela escolha do Papel.<br/>
-O Papel é independente do seu estilo de Combate ou Grimo que escolheu para jogar, ele é meramente uma escolha mecânica, e deve ser contextualizado pelas preferências de combate do seu personagem.
+O Papel de jogo também ajuda a definir qual será o seu "objetivo" dentro de um combate. Ou seja, se quiser criar um personagem que **aguente o dano dos inimigos** e evite que seus **aliados recebam dano**, talvez queira escolher o **Papel de Tanque**, pois esse papel lhe dará uma base superior de **Pontos de Vida**, além de permitir que você prenda a atenção dos inimigos por mais tempo.
 
-Se quer criar um personagem que aguente o dano dos inimigos e consiga sobreviver por mais tempo, talvez queira escolher o Papel "Tanque", pois esse papel lhe dará uma base superior de **Pontos de Vida**.
-
-Já se o seu objetivo é criar um Mago destruidor, cujo objetivo é incendiar o campo de batalha com uma leque diverso de magias, talvez você prefira o Papel do **Conjurador**, pois nesse Papel você terá, além de uma boa base de **Pontos de Magia** iniciais, um valor de **Ataque Mágico** razoável para acertar os seus feitiços nos inimigos!
+Já se o seu objetivo é criar um Mago destruidor, cujo objetivo é incendiar o campo de batalha com um leque diverso de magias, talvez você prefira o **Papel do Conjurador**, pois nele você terá, além de uma boa base de **Pontos de Magia** iniciais, a habilidade de **potencializar seus Ataques Mágicos**, atingindo mais inimigos e causando ainda mais dano!
 
 ## Comparação dos Papéis
 

--- a/docs/5-roles/introduction.md
+++ b/docs/5-roles/introduction.md
@@ -98,15 +98,5 @@ Para ajudá-lo em sua decisão, preparamos uma tabela abaixo comparando os atrib
       <td>2/4/4/6</td>
       <td>3/3/6/6</td>
     </tr>
-    <tr>
-      <td>Bônus</td>
-      <td>Ataque Corpo-a-Corpo +1</td>
-      <td>Ataque Mágico +1</td>
-      <td>Ataque à Distância +1</td>
-      <td>Defesa Mágica +1</td>
-      <td>Defesa Física +1</td>
-      <td>Iniciativa +2</td>
-    </tr>
-
   </tbody>
 </table>

--- a/docs/5-roles/shooter.md
+++ b/docs/5-roles/shooter.md
@@ -4,6 +4,13 @@ title: Atirador
 slug: /5-roles/roles-hunter
 ---
 
+import { SpellFromJson } from './../../src/components/skill_block/index'
+
+import disengage from './../../data/spells/spells-roles/disengage.json'
+import sharp_precision from './../../data/spells/spells-roles/sharp_precision.json'
+
+![Atirador.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C4ec3f2d3-8faf-48ab-b247-a2086d04c538.jpg)
+
 O Atirador é um tipo de Carregador focado no combate a Longa Distância. Costuma focar sua build em precisão e combate estratégico.
 Personagens atiradores costumam ficar distantes no campo de batalha, oferecendo cobertura aos aliados e alto dano aos inimigos.
 
@@ -51,9 +58,11 @@ Costumam se adaptar mais com armas leves que permitem uma boa movimentação no 
       <td>Pontos de Magia por Nível</td>
       <td>+3/+3/+6/+6</td>
     </tr>
-    <tr>
-      <td>Bônus de Ataque à Distância</td>
-      <td>+1</td>
-    </tr>
   </tbody>
 </table>
+
+## Poderes do Papel
+
+<SpellFromJson expanded={false} spellData={disengage} />
+
+<SpellFromJson expanded={false} spellData={sharp_precision} />

--- a/docs/5-roles/shooter.md
+++ b/docs/5-roles/shooter.md
@@ -9,7 +9,7 @@ import { SpellFromJson } from './../../src/components/skill_block/index'
 import disengage from './../../data/spells/spells-roles/disengage.json'
 import sharp_precision from './../../data/spells/spells-roles/sharp_precision.json'
 
-![Atirador.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C4ec3f2d3-8faf-48ab-b247-a2086d04c538.jpg)
+![Se a sua especialidade é a pontaria, o papel do Atirador com certeza é pra você!](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C4ec3f2d3-8faf-48ab-b247-a2086d04c538.jpg)
 
 O Atirador é um tipo de Carregador focado no combate a Longa Distância. Costuma focar sua build em precisão e combate estratégico.
 Personagens atiradores costumam ficar distantes no campo de batalha, oferecendo cobertura aos aliados e alto dano aos inimigos.

--- a/docs/5-roles/support.md
+++ b/docs/5-roles/support.md
@@ -2,7 +2,16 @@
 id: roles-priest
 title: Suporte
 slug: /5-roles/roles-priest
+image: https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Ccdb2e228-9546-40ec-a8de-92a16e5f080f.jpg
 ---
+
+import { SpellFromJson } from './../../src/components/skill_block/index'
+import save_ally from
+'./../../data/spells/spells-roles/save_ally.json'
+
+import power_heal from './../../data/spells/spells-roles/power_heal.json'
+
+![O Suporte é a Pilar de Luz de um bom grupo! Quer saber como utilizá-los?](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Ccdb2e228-9546-40ec-a8de-92a16e5f080f.jpg)
 
 O Papel de Suporte geralmente é utilizado por personagens que não priorizam o dano no combate.
 
@@ -51,9 +60,11 @@ Devido a utilização de muitas habilidades à distância, esses personagens nã
       <td>Pontos de Magia por Nível e Tier</td>
       <td>+5/+5/+10/+10</td>
     </tr>
-    <tr>
-      <td>Bônus de Defesa Mágica</td>
-      <td>+1</td>
-    </tr>
   </tbody>
 </table>
+
+## Poderes do Papel
+
+<SpellFromJson expanded={false} spellData={save_ally} />
+
+<SpellFromJson expanded={false} spellData={power_heal} />

--- a/docs/5-roles/tank.md
+++ b/docs/5-roles/tank.md
@@ -2,20 +2,28 @@
 id: roles-tank
 title: Tanque
 slug: /5-roles/roles-tank
+image: https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C066e8c6a-02c4-4dda-92ea-6ded02de30ee.jpg
 ---
 
-O Tanque é um papel de Defesa, focado em puxar a atenção do maior número de inimigos para si, para que o grupo tenha tempo de agir.
+import { SpellFromJson } from './../../src/components/skill_block/index'
 
-No campo de batalha preferem gerar a maior exposição possível, devido a sua alta capacidade de sobrevivência.
+import taunt from './../../data/spells/spells-roles/taunt.json'
+import defense_stance from './../../data/spells/spells-roles/defense_stance.json'
 
-Possuem uma quantidade superior de Pontos de Vida, sendo ideais para liderar o campo de batalha sem correr grandes riscos.
+![Então quer se tornar um Tanque...mas será que você tem o que é preciso?](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C066e8c6a-02c4-4dda-92ea-6ded02de30ee.jpg)
+
+O Tanque é um papel de Defesa e Proteção, focado em puxar a atenção do maior número de inimigos para si, permitindo que o grupo tenha tempo de agir.
+
+No campo de batalha preferem ficar próximos aos inimigos, gerando a maior exposição possível, devido a sua alta capacidade de sobrevivência.
+
+Possuem uma quantidade superior de **Pontos de Vida**, assim como uma progressão melhor, sendo ideais para liderar o campo de batalha sem correr grandes riscos.
 
 ## Você deve escolher este Papel se...
 
 - Seu objetivo primário não é causar dano.
 - Prioriza o auxílio e suporte a seus aliados.
 - Não prioriza tanto a movimentação no combate.
-- Prefere utilizar armas baseadas em atributos mágicos, como Cetros, Orbes e Cajados
+- Prefere utilizar escudos e armas baseadas em Resiliência e Força.
 
 ## Características Iniciais
 
@@ -51,9 +59,11 @@ Possuem uma quantidade superior de Pontos de Vida, sendo ideais para liderar o c
       <td>Pontos de Magia por Nível e Tier</td>
       <td>+2/+4/+4/+6</td>
     </tr>
-    <tr>
-      <td>Bônus de Defesa Física</td>
-      <td>+1</td>
-    </tr>
   </tbody>
 </table>
+
+## Poderes do Papel
+
+<SpellFromJson expanded={false} spellData={taunt} />
+
+<SpellFromJson expanded={false} spellData={defense_stance} />

--- a/docs/5-roles/utility.md
+++ b/docs/5-roles/utility.md
@@ -19,8 +19,9 @@ Os Utilitários são como Canivetes Suíços, oferecendo grande flexibilidade de
 
 ## Você deve escolher este Papel se...
 
-- Seu objetivo primário pode váriar entre papéis.
+- Seu estilo de batalha pode variar dependendo da situação.
 - Você não prioriza causar o maior dano ou fornecer o melhor suporte.
+- Você quer sempre ser útil para o seu time no momento certo.
 
 ## Características Iniciais
 

--- a/docs/5-roles/utility.md
+++ b/docs/5-roles/utility.md
@@ -4,6 +4,13 @@ title: Utilitário
 slug: /5-roles/roles-fortuner
 ---
 
+import { SpellFromJson } from './../../src/components/skill_block/index'
+
+import utility_initiation from './../../data/spells/spells-roles/utility_initiation.json'
+import utility_manouver from './../../data/spells/spells-roles/utility_manouver.json'
+
+![Utility.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cbfe59347-e049-47aa-8a50-0fc40a093574.jpg)
+
 Os personagens utilitários são aqueles cujo Papel de Jogo pode variar imensamente durante o combate.
 
 Eles possuem um leque flexível de habilidades, que variam entre causar dano, controlar e fornecer suporte aos aliados.
@@ -49,9 +56,11 @@ Os Utilitários são como Canivetes Suíços, oferecendo grande flexibilidade de
       <td>Pontos de Magia por Nível</td>
       <td>+3/+3/+6/+6</td>
     </tr>
-     <tr>
-      <td>Bônus de Iniciativa</td>
-      <td>+2</td>
-    </tr>
   </tbody>
 </table>
+
+## Poderes do Papel
+
+<SpellFromJson expanded={false} spellData={utility_initiation} />
+
+<SpellFromJson expanded={false} spellData={utility_manouver} />

--- a/docs/7-game-rules/blacksmiths.md
+++ b/docs/7-game-rules/blacksmiths.md
@@ -90,7 +90,7 @@ O refinamento é uma técnica **extremamente arriscada**, e se não for feita da
 
 Para refinar, o Narrador usará a **Habilidade do Ferreiro** como um **teste especial de Resistência**. (por padrão, a *Habilidade de Ferreiros* comuns é **20**)
 
-O **Narrador** então rolará <code>X+1 D20</code>, onde X é a Qualidade final que o Personagem deseja alcançar.
+O **Narrador** então rolará <code>X+1 D20</code>, onde X é a **quantidade de vezes** que esse item já foi refinado anteriormente.
 
 Caso a soma dos D20 rolados **não ultrapasse** a *Habilidade do Ferreiro* **(padrão 20)**, o Item **recebe +1 de Qualidade**, *(ex: Se for Arma, recebe +1 de Ataque, se for Armadura, recebe +1 de Defesa).*
 

--- a/docs/7-game-rules/challenge-checks.md
+++ b/docs/7-game-rules/challenge-checks.md
@@ -21,10 +21,10 @@ Um exemplo de uma **ação desse tipo** é a Ação para se **defender de um ata
 
 Para realizar uma ação desse tipo, o Narrador **definirá um número** *(secretamente ou não)* do qual você **deverá superar** se quiser **ser bem sucedido**. Chamamos esse número de **Dificuldade do Teste**.
 
-Assim como a **tabela fixa** dos **Testes de Perícia**, rolar um resultado que esteja até **5 pontos abaixo** do valor de dificuldade resultará em uma **jogada imperfeita**. Da mesma forma, qualquer valor igual ou superior à **Dificuldade do Teste** será considerado como um **Sucesso**.
+Assim como a **tabela fixa** dos **Testes de Perícia**, rolar um resultado que esteja abaixo do valor de dificuldade resultará em uma **Falha**. Da mesma forma, qualquer valor igual ou superior à **Dificuldade do Teste** será considerado como um **Sucesso**.
 
 Da mesma forma, **rolar 1 ou 20** também **resultará em um Desastre ou Triunfo**, respectivamente.
 
 **Uma forma de visualizar** os tipos de resultados de uma **Ação de Desafio** seria a seguinte:
 
-![ChallengeRoll.png](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C435ea233-fc20-4740-a77e-af4cd1d4139b.png)
+![ChallengeRoll](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C1f674489-3efd-4c21-ad29-4293c805ccf0.png)

--- a/docs/7-game-rules/skill-checks.md
+++ b/docs/7-game-rules/skill-checks.md
@@ -40,7 +40,7 @@ Mas uma Falha **nem sempre** significa que você fracassou totalmente. Deixamos 
 
 No contexto de um combate por exemplo, uma **Falha de Ataque** nem sempre significa que você **errou um ataque** sem causar dano. O Narrador pode decidir que você **conseguiu causar dano ao alvo**, mas a **forma como você realizou essa ação** pode vir acompanhada de algumas **consequências**.
 
-Descrevemos algumas dessas consequências no [Capítulo 9: Regras de Combate](/docs/9-combat-rules/physical-combate).
+Descrevemos algumas dessas consequências no [Capítulo 9: Regras de Combate](/docs/9-combat-rules/physical-combat).
 
 *Se você estava tentando atacar um oponente com sua espada, uma falha pode significar apenas que seu ataque não foi bem sucedido, e o inimigo conseguiu desviar do ataque; Se você estiver abrindo uma fechadura, uma falha significa que seus esforços não foram suficientes para destravar o mecanismo.*
 

--- a/docs/7-game-rules/skill-checks.md
+++ b/docs/7-game-rules/skill-checks.md
@@ -24,7 +24,7 @@ Seguindo as regras do [Sistema 2d20](/docs/8-system-2d20/system-introduction), p
 
 Para saber se passou no teste, você **deverá rolar o dado** e **comparar** o resultado com a **tabela abaixo**. Dependendo do **tipo da rolagem**, sua ação será caracterizada de uma **forma diferente**. Falaremos também de cada um desses resultados:
 
-![SkillRolls.png](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C9865f9f1-9159-42b7-89f7-97cac63592e5.png)
+![SkillRolls.png](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5C58b75b7b-5df0-4245-a2e9-7e6bec013012.png)
 
 ### Desastre
 
@@ -34,15 +34,17 @@ Tirar 1 no dado significa rolar um **Desastre**, e significa que sua ação não
 
 ### Falha
 
-Tirar uma Falha significa que você não conseguiu realizar a ação que desejava. Na maioria das vezes, você saberá instantaneamente que fracassou, e poderá tentar de novo, **caso o Narrador permita**. Falhas também podem acontecer em **combates** durante **ataques**.
+Tirar uma Falha significa que você não foi capaz de realizar a ação da forma que desejava. Na maioria das vezes, você saberá instantaneamente que fracassou, e poderá tentar de novo, **caso o Narrador permita**. Falhas também podem acontecer em **combates** durante **ataques**.
 
-*Se você estava tentando atacar um oponente com sua espada, uma falha apenas indica que seu ataque não foi bem sucedido, e o inimigo conseguiu desviar do ataque; Se você estiver abrindo uma fechadura, uma falha significa que seus esforços não foram suficientes para destravar o mecanismo.*
+Mas uma Falha **nem sempre** significa que você fracassou totalmente. Deixamos essa interpretação em aberto para que os Narradores **possam manobrar falhas** e interpretá-las como **"ações imperfeitas"**. Nesse caso, parte da sua ação poderia ser bem sucedida, mas viriam acompanhadas de algumas **consequências**.
 
-### Imperfeição
+No contexto de um combate por exemplo, uma **Falha de Ataque** nem sempre significa que você **errou um ataque** sem causar dano. O Narrador pode decidir que você **conseguiu causar dano ao alvo**, mas a **forma como você realizou essa ação** pode vir acompanhada de algumas **consequências**.
 
-Tirar um resultado imperfeito significa que você até conseguiu realizar a ação que desejava, mas sua ação gerou **complicações**. Talvez você tenha agido de forma desajeitada, ou talvez não esteja num dia bom.
+Descrevemos algumas dessas consequências no [Capítulo 9: Regras de Combate](/docs/9-combat-rules/physical-combate).
 
-*Talvez você esteja no alto de um penhasco, avistando uma pequena tropa de inimigos viajando na estrada abaixo. Você vê um grande pedregulho, e tenta empurrá-lo em cima dos inimigos, mas uma rolagem imperfeita faz com que você se desequilibre, e caia junto com o pedregulho.*
+*Se você estava tentando atacar um oponente com sua espada, uma falha pode significar apenas que seu ataque não foi bem sucedido, e o inimigo conseguiu desviar do ataque; Se você estiver abrindo uma fechadura, uma falha significa que seus esforços não foram suficientes para destravar o mecanismo.*
+
+*Da mesma forma, falhar ao empurrar um grande pedregulho sobre seus inimigos, não precisa significar que você não teve forças para empurrá-lo, mas que ao tentar empurrá-lo, você pode ter se desequilibrado, caindo junto com ele.*
 
 ### Sucesso
 

--- a/docs/9-combat-rules/durability.md
+++ b/docs/9-combat-rules/durability.md
@@ -31,7 +31,7 @@ As **Cargas de Desgaste** podem ser acumuladas em diversas ocasiões. Abaixo lis
 - Ao rolar uma **falha crítica** num teste de Defesa Física ou Mágica.
 - Ao ser afetado por um **poder inimigo** que reduz Durabilidade.
 - Ao utilizar seus equipamentos de **forma imprudente** e não segura.
-- Como consequência de um [Sucessos imperfeito](/docs/7-game-rules/skill-checks).
+- Como consequência de um [Falha](/docs/7-game-rules/skill-checks). (usar com cautela)
 
 As cargas devem ser recebidas de forma contextual, logo, é importante que o Narrador avalie se aquela situação realmente se traduziu num dano de Durabilidade à Arma.
 

--- a/docs/9-combat-rules/magical-combat.md
+++ b/docs/9-combat-rules/magical-combat.md
@@ -54,7 +54,9 @@ Alguns poderes mágicos, como a [Pancada, do Grimo de Giurad](/docs/4-grimos-and
 
 Todos os testes de Ataques são considerados **Ações de Desafio**. É o Narrador que determina qual é a **dificuldade do teste**. Um **Ataque Mágico** será bem sucedido se o resultado da rolagem de ataque **superar a Defesa Mágica do Inimigo**.
 
-Mas caso você não ultrapasse esse resultado, ainda é possível obter um **Sucesso Imperfeito**, que faz com que seu Dano/Efeito seja aplicado normalmente*, mas pode gerar algumas consequências. Na tabela abaixo listamos algumas **consequências** que o Narrador pode utilizar neste tipo de ocasião rolando um D8:
+Caso você não ultrapasse esse resultado, sua ação é considerada como uma **Falha**. Por padrão, uma falha significa que seu ataque não acertou o alvo. Mas o Narrador pode interpretar sua ação dependendo do contexto, e decidir que você cause dano no inimigo, ao mesmo em que sua ação gera algumas **consequências negativas**.
+
+Na tabela abaixo listamos algumas **consequências** que o Narrador pode utilizar neste tipo de ocasião rolando um D8:
 
 | D8 | Se aplica a | Descrição |
 | ------------- | ----------- | --------- |
@@ -67,7 +69,7 @@ Mas caso você não ultrapasse esse resultado, ainda é possível obter um **Suc
 | 7 | Ambiente | Seu ataque atinge o inimigo normalmente, mas uma reação em cadeia atinge um elemento do ambiente que de alguma forma cria uma vantagem para os inimigos. |
 | 8 | Ambiente | Seu ataque atinge o inimigo normalmente, mas uma reação em cadeia atrai um inimigo adicional ao combate. |
 
-Mas essas são apenas algumas sugestões, elas não são colocadas em **forma de regra**, mas em forma de **ferramenta Narrativa** que pode ser usada para dar sentido aos **Sucessos Imperfeitos**.
+Mas essas são apenas algumas sugestões, elas não são colocadas em **forma de regra**, mas em forma de **sugestão Narrativa** que pode ser usada em casos de **Falha**.
 
 ### 3. Aplicar Efeito/Dano
 
@@ -152,7 +154,9 @@ Seja como for, a fórmula para determinar o resultado do **teste de Defesa Mági
 
 Todos os testes de Defesa são considerados **Ações de Desafio**. É o Narrador que determina qual é a **dificuldade do teste**. Uma **Defesa Mágica** será bem sucedida se o resultado da rolagem de ataque **superar o Ataque Mágico do Inimigo**.
 
-Mas caso você não ultrapasse esse resultado, ainda é possível obter um **Sucesso Imperfeito**, que faz com que sua defesa seja bem sucedida, mas com possíveis consequências. Na tabela abaixo listamos algumas **consequências** que o Narrador pode utilizar neste tipo de ocasião rolando um D8:
+Caso você não ultrapasse esse resultado, o seu teste é considerado como uma **Falha**. Por padrão, uma falha significa que você foi capaz de se defender de seu inimigo, mas o Narrador pode interpretar sua ação dependendo do contexto, e decidir que você cause dano, ao mesmo tempo em que sua ação gera algumas **consequências negativas**.
+
+Na tabela abaixo listamos algumas **consequências** que o Narrador pode utilizar neste tipo de ocasião rolando um D8:
 
 | D8 | Se aplica a | Descrição |
 | ------------- | ----------- | --------- |
@@ -165,7 +169,7 @@ Mas caso você não ultrapasse esse resultado, ainda é possível obter um **Suc
 | 7 | Ambiente | O personagem se defende do ataque, mas uma reação em cadeia atinge um elemento do ambiente que de alguma forma cria uma vantagem para os inimigos. |
 | 8 | Ambiente | O personagem se defende do ataque, mas um outro inimigo percebe uma abertura em sua guarda e pode realizar uma ação de ataque contra ele imediatamente com **+2 de Bônus**. |
 
-Mas essas são apenas algumas sugestões, elas não são colocadas em **forma de regra**, mas em forma de **ferramenta Narrativa** que pode ser usada para dar sentido aos **Sucessos Imperfeitos**.
+Mas essas são apenas algumas sugestões, elas não são colocadas em **forma de regra**, mas em forma de **sugestão Narrativa** que pode ser usada em casos de **Falha**.
 
 ### 3. Resolução do Efeito/Dano
 

--- a/docs/9-combat-rules/physical-combat.md
+++ b/docs/9-combat-rules/physical-combat.md
@@ -7,27 +7,28 @@ image: https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cb68
 
 ![Realizando ataques físicos e mágicos no combate](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Cb687fb37-c726-4023-b592-7f6e98c945be.jpg)
 
-
-
 Todos os Personagem podem equipar armas (ou até mais de uma), e cada ataque com uma Arma consome uma única **Ação Maior**.
 
-O ataque com armas físicas é uma das **ações mais comuns** de um combate. Seja uma espada, um machado ou uma besta, você verá que todos seguem a mesma regra.
+O ataque com armas é uma das **ações mais comuns** de um combate. Seja uma espada, uma Orbe ou uma besta, você verá que todos seguem mais ou menos a mesma regra.
 
-Nesta seção falaremos sobre o Ataque e Defesa com Armas físicas, ou seja, aquelas que causam **Dano Físicos no oponente** e não dependem de magia para funcionar.
+Nesta seção falaremos sobre dois tipos de Armas:
+
+1. O Ataque e Defesa com Armas físicas, ou seja, aquelas que causam **Dano Físico no oponente** e não dependem de magia para funcionar.
+2. O Ataque e Defesa com Armas mágicas, ou sseja, aquelas que causam **Dano Mágico no oponente** e dependem de alguma magia para funcionar.
 
 ## Atacando com uma Arma
 
-Uma jogada de Ataque no jogo é sempre realizada em duas etapas:
+Independente do tipo da sua arma, uma jogada de Ataque no jogo é sempre realizada em três etapas:
 
-1. Teste de Ataque
+1. Teste de Acerto
 2. Determinando o Sucesso
 3. Rolagem do Dano
 
 ### 1. Teste de Acerto
 
-O objetivo desta etapa é **determinar se você consegue ou não acertar** o seu inimigo. 
+O objetivo desta etapa é **determinar se você consegue ou não acertar** o seu inimigo.
 
-Falhar em um *teste de ataque* é possível, o que significa que o seu ataque talvez *tenha sido aparado pela arma ou escudo do inimigo*, ou talvez não tenha sido forte o bastante para *penetrar as densas escamas de uma criatura*, ou quem sabe você só se *atrapalhou* e *errou a mira* mesmo!
+Falhar em um *teste de ataque* é possível, o que significa que o seu ataque talvez *tenha sido aparado pela arma ou escudo do inimigo*, ou talvez não tenha sido forte o bastante para *penetrar as densas escamas de uma criatura*. (ou quem sabe você só se *atrapalhou* e *errou a mira* mesmo!)
 
 A fórmula para determinar o resultado do **teste de ataque** é:
 
@@ -39,7 +40,13 @@ Lembrando que os *Bônus* e o *Ataque da Arma* devem ser somados ao **número ma
 
 Todos os testes de Ataques são considerados [Ações de Desafio](/docs/7-game-rules/challenge-checks). É o Narrador que determina qual é a dificuldade do teste numa **Ação de Desafio**. Como já explicado no capítulo anterior, um Sucesso é obtido quando o resultado de um dos dois D20 é superior ao valor da **Dificuldade do Teste** (apenas conhecido pelo Narrador)
 
-Mas caso você não ultrapasse esse resultado, ainda é possível obter uma **Ação Imperfeita**, que faz com que seu Dano seja aplicado normalmente, mas pode gerar algumas consequências. Na tabela abaixo listamos algumas consequências que o Narrador pode utilizar neste tipo de ocasião:
+O ataque poderá ser testado tanto contra a **defesa física do inimigo** (no caso de armas físicas como Espadas e Machados), ou contra a **defesa mágica do inimigo** (no caso de armas mágicas como Orbes e Livros). Lembrando a **menos que a Arma especifique o contrário**, todos projéteis mágicos gerados por essas armas são considerados **não-elementais**.
+
+Mas caso você não ultrapasse a defesa física/mágica do inimigo, sua ação é considerada uma **Falha**. Uma falha não significa necessariamente que você não causará nenhum dano, já que essa decisão é tomada de forma arbitrária pelo Narrador, mas na maioria das vezes é isso que costuma acontecer.
+
+Uma **Falha** sempre significa que sua ação causou um **efeito negativo**. Por padrão, ela significa que seu ataque **não causou dano** ao alvo, mas se o Narrador quiser, ele pode arbitrariamente interpretar essa ação de forma diferente, permitindo que você causa dano, mas trazendo em contrapartida **efeitos negativos** para você ou para seus aliados.
+
+Na tabela abaixo listamos algumas **consequências** que o Narrador pode utilizar neste tipo de ocasião:
 
 | Se aplica a | Descrição |
 | ----------- | --------- |
@@ -49,7 +56,7 @@ Mas caso você não ultrapasse esse resultado, ainda é possível obter uma **A�
 | Aliados próximos | A arma atinge o inimigo normalmente, mas rebate ou acidentalmente atinge um aliado, aplicando nele metade do dano. |
 | Aliados próximos | O personagem faz o ataque de forma atrapalhada, e sem querer esbarra em um aliado, lançando a arma dele a 1d6 quadrados de distância em qualquer direção. |
 | Armas de Projéteis | A arma realiza o ataque, mas recebe o modificador **Emperrada 1** no próximo turno. |
-| Armas de Projéteis | A arma realiza o ataque, mas ao invés de atingir o inimigo desejado, atinge um outro inimigo. |
+| Armas de Projéteis | A arma realiza o ataque, mas ao invés de atingir o inimigo desejado, atinge um outro inimigo. (pode ser utilizado quando o resultado quase atingiu o limiar do sucesso) |
 | Armas Mágicas | A arma realiza o ataque, mas recebe o modificador **Anulada 1** no próximo turno. |
 | Ambiente | Seu ataque atinge o inimigo normalmente, mas seu movimento atrapalhado derruba um objeto do cenário, que atinge você ou um aliado próximo. Dano a ser decidido pelo Narrador |
 | Ambiente | Seu ataque atinge o inimigo normalmente, mas uma reação em cadeia atinge um elemento do ambiente que de alguma forma cria uma vantagem para os inimigos. |
@@ -63,23 +70,23 @@ Agora basta **rolar o Dano do seu Ataque físico**, cuja formula está listada e
 
 ![Rolagem-Dano-Fisico.jpg](https://s3.us-west-2.amazonaws.com/fabulas-e-goblins-book/%5Cvscode%5Ca3e5a98f-f965-42c1-b3a3-14cf02889178.jpg)
 
-:::note Exemplo de Ataque Imperfeito
+:::note Exemplo de Falha no Ataque
 Diferente dos Personagens, os inimigos não rolam dados, e possuem seu próprio valor de **Defesa**. Esse valor é a **Dificuldade do Teste** da [Ação de Desafio](/docs/7-game-rules/challenge-checks).
 
 Exemplo:
 
-**Ramón** é um Aventureiro, e possui **Ataque +3**.
+**Ramón** é um Aventureiro, e possui **Ataque Físico +3**.
 
-Ramón atacará com seu **Machado** um **Fougrat Guerreiro**, cuja **Defesa é 15**. <br/>
+Ramón atacará com seu **Machado** (uma arma Física) um **Fougrat Guerreiro**, cuja **Defesa Física é 15**. <br/>
 Secretamente, o Narrador utilizará este valor como a **Dificuldade do Teste** de Ataque.
 
-**Nosso Aventureiro** então deve **rolar 2D20** para determinar se ele conseguirá **acertar o ataque** no Fougrat.
+**Nosso Aventureiro** então deve **rolar 2d20** para determinar se ele conseguirá **acertar o ataque** no Fougrat.
 
 **O resultado dos dois 2d20 são 9 e 10**. Ramón seleciona o maior valor (10), e soma a ele seu bônus de **+3 de Ataque**.
 
-Infelizmente, mesmo assim o **valor de 13** não é suficiente para obter um sucesso, já que a **Defesa do Fougrat é 15**, mas de acordo com as regras da [Ação de Desafio](/docs/7-game-rules/challenge-checks), essa pode ser considerada uma **jogada Imperfeita**.
+Infelizmente, mesmo assim o **valor de 13** não é suficiente para obter um sucesso, já que a **Defesa do Fougrat é 15**, mas de acordo com as regras da [Ação de Desafio](/docs/7-game-rules/challenge-checks), o Narrador pode interpretar essa ação arbitrariamente.
 
-O Narrador então **permite que Ramón acerte o Fougrat**, mas como consequência da **jogada imperfeita**, ele diz que **Ramón gira o machado para acertar o Fougrat**, mas acaba acidentalmente **acertando um aliado que estava próximo**, causando no aliado metade do Dano que ele causou na criatura.
+O Narrador então **permite que Ramón acerte o Fougrat normalmente**, mas como consequência de uma **jogada imperfeita**, ele diz que **Ramón gira o machado para acertar o Fougrat**, mas acaba acidentalmente **acertando um aliado que estava próximo**, causando no aliado **metade do Dano** que ele causou na criatura.
 :::
 
 ## Defendendo-se de um Ataque Físico
@@ -90,7 +97,7 @@ Defender é o ato de bloquear, absorver ou aparar um golpe inimigo direto.
 
 Mas no nosso sistema, os **inimigos não fazem rolagens de ataque**, e por isso, para se Defender, você também dependerá dos dados.
 
-Enquanto no Ataque você rola dados para superar a *Defesa inimiga* utilizando seus **Pontos de Ataque**, na Defesa você rola dados para superar o *Ataque inimigo* utilizando os seus **Pontos de Defesa**. 
+Enquanto no Ataque você rola dados para superar a *Defesa inimiga* utilizando seus **Pontos de Ataque**, na Defesa você rola dados para superar o *Ataque inimigo* utilizando os seus **Pontos de Defesa**.
 
 ### Defendendo
 
@@ -106,9 +113,9 @@ Na maioria das vezes você vai **querer evitar** um ataque inimigo bem sucedido,
 
 ### 1. Teste de Defesa
 
-O objetivo desta etapa é **determinar se você consegue ou não desviar/aparar/absorver** o ataque de seu inimigo. 
+O objetivo desta etapa é **determinar se você consegue ou não desviar/aparar/absorver** o ataque de seu inimigo.
 
-Falhar em um *teste de defesa* é possível, o que significa que você **não conseguiu de Defender de forma eficiente**. 
+Falhar em um *teste de defesa* é possível, o que significa que você **não conseguiu de Defender de forma eficiente**.
 
 Nessas ocasiões, podemos interpretar de várias maneiras: Talvez *o ataque do inimigo seja muito forte*, ou talvez a lâmina do inimigo é muito *afiada para sua armadura*, ou talvez você apenas estava mal posicionado e o *ataque te acertou em cheio*!
 
@@ -118,22 +125,28 @@ Seja como for, a fórmula para determinar o resultado do **teste de defesa** é:
 
 Lembrando que os *Bônus* e o *Ataque da Arma* devem ser somados ao **número mais alto dos 2d20**, seguindo as regras do [Sistema 2d20](/docs/8-system-2d20/system-introduction).
 
+No momento da ação, o Narrador especificará se o Ataque é Físico ou Mágico. Para ataques Físicos, você deve usar sua **Defesa Física**, já para ataques Mágicos, você deve usar sua **Defesa Mágica**.
+
 ### 2. Determinando o Sucesso da Defesa
 
 Todos os testes de Defesa são considerados [Ações de Desafio](/docs/7-game-rules/challenge-checks). É o Narrador que determina qual é a dificuldade do teste numa **Ação de Desafio**. Como já explicado no capítulo anterior, um Sucesso é obtido quando o resultado de um dos dois D20 é superior ao valor da **Dificuldade do Teste** (apenas conhecido pelo Narrador)
 
-Mas caso você não ultrapasse esse resultado, ainda é possível obter uma **Ação Imperfeita**, que faz com que sua Defesa seja bem sucedida, mas com algumas consequências. Na tabela abaixo listamos algumas consequências que o Narrador pode utilizar neste tipo de ocasião:
+Caso você não ultrapasse o valor de **Ataque inimigo** (que pode ser físico ou mágico), sua ação será considerada uma **Falha**. Falhar em uma Defesa não significa que você receberá **todo o dano que o inimigo pretendeu te causar**, já que essa decisão é tomada de forma arbitrária pelo Narrador, mas na maioria das vezes é isso que costuma acontecer.
+
+Uma **Falha** sempre significa que sua ação causou um **efeito negativo**. Por padrão, ela significa que você recebeu **todo o dano que o inimigo pretendeu te causar**, mas se o Narrador desejar, também pode significar que você **recebeu dano parcialmente**, ou que a **forma como você se defendeu** desse dano **tenha trazido efeitos negativos** para você ou para seus aliados.
+
+Na tabela abaixo listamos algumas consequências que o Narrador pode utilizar neste tipo de ocasião:
 
 | Se aplica a | Descrição |
 | ----------- | --------- |
-| Qualquer arma | O jogador consegue se defender com sua Arma, mas ela é lançada 1d6 quadrados de distância em qualquer direção. |
+| Qualquer arma | O jogador utiliza sua Arma para se defender, mas no impacto ela é lançada 1d6 quadrados em qualquer direção. |
 | Qualquer arma | O personagem tropeça após a Defesa, recebendo o modificador **Derrubado 1** até o próximo turno. |
 | Qualquer arma | O personagem se defende apenas parcialmente, recebendo **metade do Dano** que seria causado normalmente com um **sucesso** |
 | Aliados próximos | Você repele o ataque inimigo, mas seu posicionamento atrapalhado direciona o ataque inimigo a um aliado adjacente, que recebe metade do dano que você receberia. |
 | Aliados próximos | O personagem se defende de forma atrapalhada, e sem querer esbarra em um aliado no processo, lançando a arma dele a 1d6 quadrados de distância em qualquer direção. |
-| Armas de Projéteis | A Defesa é bem sucedida, mas uma parte de seu Equipamento se desprende do corpo temporariamente, **fornecendo -1 de Defesa** até que seja recuperado. |
+| Armas de Projéteis | A Defesa é bem sucedida, mas uma parte de seu Equipamento se desprende do corpo temporariamente, **fornecendo -2 de Defesa** até que seja recuperado. |
 | Armas Mágicas | O personagem bloqueia o ataque com sua arma mágica, que devido ao forte impacto, recebe a condição **Anulada 1** no próximo turno. |
-| Ambiente | O personagem bloqueia o ataque, mas seu movimento atrapalhado derruba um objeto do cenário, que atinge você ou um aliado próximo. Dano a ser decidido pelo Narrador |
+| Ambiente | O personagem bloqueia o ataque, mas seu movimento atrapalhado derruba um **objeto do cenário**, que atinge você ou um aliado próximo. Dano a ser decidido pelo Narrador |
 | Ambiente | O personagem bloqueia o ataque, mas uma reação em cadeia atinge um elemento do ambiente que de alguma forma cria uma vantagem para os inimigos. |
 | Ambiente | O personagem bloqueia o ataque, mas uma reação em cadeia atrai um inimigo adicional ao combate. |
 
@@ -157,7 +170,7 @@ Secretamente, o Narrador utilizará este valor como a **Dificuldade do Teste** d
 
 **O resultado dos dois 2d20 são 9 e 10**. Ramón seleciona o maior valor (10), e soma a ele seu bônus de **+3 de Defesa**.
 
-Infelizmente, mesmo assim o **valor de 13** não é suficiente para obter um sucesso, já que o **Ataque do Fougrat é 15**, mas de acordo com as regras da [Ação de Desafio](/docs/7-game-rules/challenge-checks), essa pode ser considerada uma **jogada Imperfeita**.
+Infelizmente, mesmo assim o **valor de 13** não é suficiente para obter um sucesso, já que o **Ataque do Fougrat é 15**, mas de acordo com as regras da [Ação de Desafio](/docs/7-game-rules/challenge-checks), o Narrador pode interpretar essa ação arbitrariamente.
 
-O Narrador então **permite que Ramón bloqueie o Ataque do Fougrat**, mas como consequência da **jogada imperfeita**, ele diz que **o potente Ataque do Fougrat fez com que uma peça da Armadura de Ramón se descolasse de seu corpo**, gerando uma penalidade permanente de **-1 de Defesa** até que a peça seja **recuperada e a armadura seja reparada**.
+Por fim, ele **permite que Ramón bloqueie o Ataque do Fougrat**, mas como consequência de uma **jogada imperfeita**, ele diz que **o potente Ataque do Fougrat fez com que uma peça da Armadura de Ramón se descolasse de seu corpo**, gerando uma penalidade permanente de **-2 de Defesa** até que a peça seja **recuperada e a armadura seja reparada**.
 :::

--- a/docs/making-off/book-structure.md
+++ b/docs/making-off/book-structure.md
@@ -1,0 +1,70 @@
+---
+id: book-structure
+title: Estrutura do Livro
+slug: /making-off/book-structure
+---
+
+# Níveis de Conteúdo
+
+- Nível de Parágrafo: A menor unidade de um conteúdo, representada por um bloco de texto
+- Nível de Bloco: Um Bloco possui um ou mais Parágrafos.
+- Nível de Seção: Uma Seção possui um ou mais Blocos.
+- Nível de Capítulo: Um Capitulo possui uma ou mais Seções.
+
+# Textos e Títulos
+
+---
+
+### Parágrafo
+
+Corpo do Livro, provavelmente precedido de um título e onde estará concentrado grande parte do conteúdo do livro.
+
+### Título de Parágrafo
+
+Um texto de display que pode preceder um bloco de **Parágrafo**, usado para quebrar uma seção complexa em sub-seções.
+
+---
+
+### Parágrafo de Bloco
+
+Não precisa ter distinção do estilo do Parágrafo.
+
+### Título de Bloco
+
+Um texto de display de peso maior que o Título de Parágrafo, geralmente usado para descrever uma Seção com um ou mais **Títulos de Parágrafo**.
+
+---
+
+### Título de Seção
+  Geralmente um texto de Display grande que introduz o usuário a uma seção de um parágrafo dentro de um Capítulo.
+
+### Texto de Seção
+  O texto explicativo de uma seção. Supostamente esse deve ser um texto contendo apenas alguns parágrafos, já que ele deve ocupar um bom espaço na página.
+
+---
+
+### Título de Capítulo
+  Geralmente um texto de Display grande que introduz o usuário a um novo Capítulo.
+
+### Texto de Capítulo
+  Opcional, mas pode ser utilizado para introduzir um Capítulo. Geralmente sucinto.
+
+---
+
+# Tabelas
+
+Tabelas Explicativas, que visam organizar certo tipo de informação mecânica ou criativa para que seja facilmente digerida pelo jogador.
+
+# Blocos
+
+## Bloco de Dica
+
+Um card em destaque com uma identidade constante que tem como objetivo dar uma meta-dica para o Personagem ou Narrador.
+
+## Bloco de Narração
+
+Um card em destaque com uma identidade constante que tem como objetivo Narrar uma cena fantasiosa ou descrever uma situação imaginária do mundo de jogo.
+
+## Bloco de Poder
+
+Um bloco especial que tem como objetivo descrever uma determinada habilidade ou poder do jogo.

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,7 +56,6 @@ const sidebars = {
         'sheet-creation/defining-initiative'
       ],
       '3. Espécies Jogáveis': [
-        'species/species-introduction',
         'species/specie-goblins',
         'species/specie-armadons',
         'species/specie-metaloids',


### PR DESCRIPTION
## O que muda?

Após diversas sessões de Playtest, eu percebi uma série de inconsistências mecânicas e outras coisas que estavam mal documentadas, e agora decidi fazer um Pull Request contendo todas as correções num lugar só.

Changelog de mudanças:
- Rebalanceamento completo do sistema de Papéis. Não fornecem mais bônus de ataque, a agora possuem habilidades únicas.
- Agilidade agora não fornece mais Defesa Física. A Fórmula de Defesa Física agora fica: **Força + Resiliência**.
- Adicionada observações sobre limites de atributo de Personagem na seção de explicação de Balanceamento.
- Refinamento de Itens agora considera a quantidade de refinos ao invés do valor de refino final.
- Habilidade passiva do Povo Livre agora especifica Pontos de Vida da montaria, além de receber +2 de Movimento.
- O termo Ataque Físico na Criação de Personagem foi substituído por **Ataque Principal**. Agora a seção também explica a diferença entre Armas Físicas e Mágicas.
- Resultados Imperfeitos deixam de existir, e passam a ser considerados Falhas sob arbitragem do Narrador.
- Adicionado Atributos em todas as Armas das seções de Grimo.
- Poder racial **Vantagem do Goblin** agora especifica restrições de uso com limite de atributo.
- Proficiência de Armas do Grimo de Giurad foi substituída pelo **Folego de Herói**.
- Especificada dúvida sobre Dano Mágico vs Ataque Físico no poder **Disparo Letal**.