### PR TITLE
💹 Adiciona vercel analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,6 +22,9 @@ const config = {
   favicon: 'img/favicon.ico',
   organizationName: 'renatodex', // Usually your GitHub org/user name.
   projectName: 'fabulas-e-goblins', // Usually your repo name.
+  clientModules: [
+    './src/analytics.js',
+  ],
 
   presets: [
     [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "18",
     "@types/react-dom": "18",
     "@ungap/url-search-params": "^0.2.2",
+    "@vercel/analytics": "^1.4.1",
     "autoprefixer": "^10.4.5",
     "clsx": "^1.1.1",
     "docusaurus-plugin-sass": "^0.2.2",

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,16 @@
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+
+export default (function () {
+  if (!ExecutionEnvironment.canUseDOM) {
+    return null;
+  }
+
+  return {
+    onRouteUpdate({ location }) {
+      // Qualquer coisa que eu queira executar em todas as páginas
+      // _paq.push(["setCustomUrl", location.pathname]);
+      // _paq.push(["setDocumentTitle", document.title]);
+      // _paq.push(["trackPageView"]);
+    },
+  };
+})();

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Footer from '@theme-original/Footer';
+import { Analytics } from "@vercel/analytics/react"
+
+export default function FooterWrapper(props) {
+  return (
+    <>
+      <Footer {...props} />
+      <Analytics />
+    </>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,6 +3338,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/url-search-params/-/url-search-params-0.2.2.tgz#2de3bdec21476a9b70ef11fd7b794752f9afa04c"
   integrity sha512-qQsguKXZVKdCixOHX9jqnX/K/1HekPDpGKyEcXHT+zR6EjGA7S4boSuelL4uuPv6YfhN0n8c4UxW+v/Z3gM2iw==
 
+"@vercel/analytics@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.4.1.tgz#a28a93133d68b6e3d86884a52fa7893f5ecaa381"
+  integrity sha512-ekpL4ReX2TH3LnrRZTUKjHHNpNy9S1I7QmS+g/RQXoSUQ8ienzosuX7T9djZ/s8zPhBx1mpHP/Rw5875N+zQIQ==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
# 💹 Adiciona vercel analytics

Por incrível que pareça eu nunca adicionei um monitoramento de analytics, então decidi tentar o Analytics da Vercel pra ver se funciona.
Aparentemente é tão simples quanto adicionar um package e colocar um componente.

Eu fiz Swizzle no componente do Footer seguindo o padrão de Wrapping do Docusaurus, e funcionou sem problemas. (https://docusaurus.io/docs/swizzling#wrapping)

Ah, antes de tentar o Swizzle, eu tinha visto uma solução no StackOverflow pra usar o clientModules do docusaurus config.
É um módulo que você pode acoplar que literalmente roda em todas as páginas.

Seria útil nesse caso, mas dai descobri que o package da vercel só funciona no React, e esse client módulo não é react.
Então apesar de não ser útil pra essa implementaçao, acabei deixando um esqueleto do arquivo no repositório, só pro caso de precisar no futuro. (https://docusaurus.io/docs/api/docusaurus-config#clientModules)