### PR TITLE
🚂 Adiciona suporte ao commit SHA da Railway

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,17 @@
 const version = require('./version.json');
-const revision = require('child_process')
-  .execSync('git rev-parse HEAD')
-  .toString().trim().substring(0,7)
+function getRevision () {
+  if (process.env.RAILWAY_GIT_COMMIT_SHA) {
+    return process.env.RAILWAY_GIT_COMMIT_SHA
+  }
+  try {
+    return require('child_process')
+      .execSync('git rev-parse HEAD', { stdio: ['pipe', 'pipe', 'ignore'] })
+      .toString().trim()
+  } catch (e) {
+    return 'unknown'
+  }
+}
+const revision = getRevision().substring(0,7)
 const path = require('path')
 let buildVersion = version.version.replace('{commit}', revision)
 


### PR DESCRIPTION
# 🚂 Adiciona suporte ao commit SHA da Railway

O `docusaurus.config.js` usava o comando `git rev-parse HEAD` pra descobrir a revisão atual e montar a versão do build.
O problema é que no ambiente de build da Railway esse comando não funciona, porque o build não tem acesso ao diretório `.git`.

Pra resolver, extraí essa lógica pra uma função `getRevision()` que funciona assim:

- Se a variável de ambiente `RAILWAY_GIT_COMMIT_SHA` existir (que é o caso do deploy na Railway), usa ela direto. (https://docs.railway.com/reference/variables#git-variables)
- Caso contrário, tenta o `git rev-parse HEAD` normalmente, que é o que acontece no ambiente local.
- Se nada disso funcionar, retorna `unknown` só pra não quebrar o build.

Aproveitei também pra silenciar o stderr do comando git, pra não poluir o log quando ele falhar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version identification during builds by using the deployment commit when available.
  * Added a reliable fallback for environments where repository information cannot be accessed.
  * Displays `unknown` instead of failing when the revision cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->